### PR TITLE
For usage with phergie/phergie-irc-plugin-react-url version 2+

### DIFF
--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -15,6 +15,7 @@ use Phergie\Irc\Bot\React\AbstractPlugin;
 use Phergie\Irc\Bot\React\EventQueueInterface as Queue;
 use Phergie\Irc\Plugin\React\Command\CommandEvent as Event;
 use Phergie\Plugin\Http\Request as HttpRequest;
+use GuzzleHttp\Message\Response;
 
 /**
  * Plugin class.
@@ -115,8 +116,8 @@ class Plugin extends AbstractPlugin
         $self = $this;
         return new HttpRequest(array(
             'url' => $provider->getApiRequestUrl($event),
-            'resolveCallback' => function ($data) use ($self, $event, $queue, $provider) {
-                $self->sendIrcResponse($event, $queue, $provider->getSuccessLines($event, $data));
+            'resolveCallback' => function (Response $response) use ($self, $event, $queue, $provider) {
+                $self->sendIrcResponse($event, $queue, $provider->getSuccessLines($event, $response));
             },
             'rejectCallback' => function ($error) use ($self, $event, $queue, $provider) {
                 $self->sendIrcResponse($event, $queue, $self->getRejectLines($error));

--- a/src/Provider/Lastfm.php
+++ b/src/Provider/Lastfm.php
@@ -102,7 +102,8 @@ class Lastfm implements AudioscrobblerProviderInterface
      */
     public function getSuccessLines(Event $event, $apiResponse)
     {
-        $response = json_decode($apiResponse);
+        $response = json_decode($apiResponse->getBody());
+
         if (isset($response->recenttracks)) {
             $messages = array($this->getSuccessMessage($response));
         } else {


### PR DESCRIPTION
For usage with [phergie/phergie-irc-plugin-react-url](https://github.com/phergie/phergie-irc-plugin-react-url) version 2 and higher the response must be handled as Guzzle object.
